### PR TITLE
Experimental support for argocd action to deploy the argo app

### DIFF
--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -335,6 +335,19 @@ spec:
         repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: main
         sourcePath: gitops
+
+    # TODO find out how to skip this if this if the argocd scaffolder plugin isn't installed
+    - id: create-argocd-resources
+      if: ${{ parameters.CI == 'tekton_argocd' }}
+      name: Create ArgoCD Resources
+      action: argocd:create-resources
+      input:
+        appName: ${{ parameters.component_id }}-bootstrap
+        argoInstance: main
+        namespace: janus-argocd
+        repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}-gitops
+        path: 'gitops/'
+
     - id: registerGitOps
       if: ${{ parameters.CI == 'tekton_argocd' }}
       name: Registering the GitOps Catalog Info Component


### PR DESCRIPTION
This is a WIP to make the basic template use the argocd create-resources action so 
if RHDH have the argocd scaffolder plugin enabled and configured we can immediately deploy
that argocd app.

The result should be a workflow  which is immediatly built and deployed and after deployment available in the orchestrator overview page. 


Signed-off-by: Roy Golan <rgolan@redhat.com>
