### PR TITLE
Backport: fixing links in software templates

### DIFF
--- a/scaffolder-templates/basic-workflow/template.yaml
+++ b/scaffolder-templates/basic-workflow/template.yaml
@@ -14,7 +14,7 @@ metadata:
     - url: https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/index.html
       title: SonataFlow Guides
       icon: techdocs
-    - url: https://www.parodos.dev/docs/core-concepts/workflow-types/
+    - url: https://www.rhdhorchestrator.io/1.2/docs/core-concepts/workflow-types/
       title: Workflow Types
       icon: techdocs
 spec:

--- a/scaffolder-templates/complex-assessment-workflow/template.yaml
+++ b/scaffolder-templates/complex-assessment-workflow/template.yaml
@@ -14,7 +14,7 @@ metadata:
     - url: https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/index.html
       title: SonataFlow Guides
       icon: techdocs
-    - url: https://www.parodos.dev/docs/core-concepts/workflow-types/
+    - url: https://www.rhdhorchestrator.io/1.2/docs/core-concepts/workflow-types/
       title: Workflow Types
       icon: techdocs
 spec:


### PR DESCRIPTION
If we are still maintaining this branch, this PR fixes some doc links