### PR TITLE
Pattern fix

### DIFF
--- a/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.]?[a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
+          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.][a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
+          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)$" # java forbids hyphens '-', argocd requires lowercase alphanumeric, k8s forbids periods '.' and requires non-number start
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)$" # java forbids hyphens '-', argocd requires lowercase alphanumeric, k8s forbids periods '.' and requires non-number start
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/github-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.]?[a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
+          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:

--- a/scaffolder-templates/github-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:

--- a/scaffolder-templates/github-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:

--- a/scaffolder-templates/github-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/github-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)$" # java forbids hyphens '-', argocd requires lowercase alphanumeric, k8s forbids periods '.' and requires non-number start
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:

--- a/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.]?[a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
+          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.][a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
+          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml
@@ -48,12 +48,12 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)$" # java forbids hyphens '-', argocd requires lowercase alphanumeric, k8s forbids periods '.' and requires non-number start
           description: Unique identifier of the workflow in SonataFlow
         infrastructureWorkflowId:
           title: Infrastructure Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)$" # java forbids hyphens '-', argocd requires lowercase alphanumeric, k8s forbids periods '.' and requires non-number start
           description: Workflow ID, the unique identifier of the infrastructure worklow available in the environment
         owner:
           title: Owner

--- a/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-zA-Z][a-zA-Z0-9]*)([.]?[a-zA-Z0-9]+)*$" # hypens '-' are not allowed to not mess with java package
+          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:

--- a/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:

--- a/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^[a-z0-9]([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)([.]?[a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:

--- a/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
+++ b/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml
@@ -49,7 +49,7 @@ spec:
         workflowId:
           title: Workflow ID
           type: string
-          pattern: "^([a-z][a-z0-9]*)([.]?[a-z][a-z0-9])*$" # hyphens '-' are not allowed, must start and end with lowercase alphanumerical values
+          pattern: "^([a-z][a-z0-9]*)$" # java forbids hyphens '-', argocd requires lowercase alphanumeric, k8s forbids periods '.' and requires non-number start
           description: Unique identifier of the workflow in SonataFlow
           default: onboarding
         owner:


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1920

These changes were tested incrementally. 

(1) Workflows with '.' in their name could be build but did not show on RHDH for error 1 below
(2) Workflows with Capital letters and numbers at the start could not be build with argocd for error 2 below.  
(3) Hyphens are allowed in argocd and k8s, but are prohibited in workflows created because of using java. 

Eventually the field of names for "workflows created by software templates, including custom java code, deployed by argocd and run on RHDH" are of names that have a lowercase alphabetical start, no hyphens, no periods, and all other chars being lowercase alphanumerical.  

Errors:
(1)
 ``` message: 'Unable to make the service available due to %!(EXTRA *errors.StatusError=Service
      "testing.bug9" is invalid: metadata.name: Invalid value: "testing.bug9": a DNS-1035
      label must consist of lower case alphanumeric characters or ''-'', start with
      an alphabetic character, and end with an alphanumeric character (e.g. ''my-name'',  or
      ''abc-123'', regex used for validation is ''[a-z]([-a-z0-9]*[a-z0-9])?''))'
```
      
(2) 
``` Error from server (Invalid): error when creating "F05EB00E.D9D7.46B1.BC27.136EB02E22E1-argocd-app-bootstrap.yaml": Application.argoproj.io "F05EB00E.D9D7.46B1.BC27.136EB02E22E1" is invalid: metadata.name: Invalid value: "F05EB00E.D9D7.46B1.BC27.136EB02E22E1": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*') ```