### PR TITLE
Use updated customer action to invoke workflow by ID

### DIFF
--- a/scaffolder-templates/github-workflows/convert-workflow-to-template/skeleton/templates/${{values.workflow_id}}/${{values.workflow_id}}.yaml
+++ b/scaffolder-templates/github-workflows/convert-workflow-to-template/skeleton/templates/${{values.workflow_id}}/${{values.workflow_id}}.yaml
@@ -19,6 +19,7 @@ spec:
       name: Run workflow
       action: orchestrator:workflow:run
       input:
+        workflow_id: ${{values.workflow_id}}
         parameters: {% raw %}${{ parameters }}{% endraw %}
 
   output:

--- a/scaffolder-templates/github-workflows/convert-workflow-to-template/skeleton/templates/${{values.workflow_id}}/${{values.workflow_id}}.yaml
+++ b/scaffolder-templates/github-workflows/convert-workflow-to-template/skeleton/templates/${{values.workflow_id}}/${{values.workflow_id}}.yaml
@@ -1,7 +1,7 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: ${{values.workflow_id}} # matches the workflow ID, will be used by orchestrator:workflow:run
+  name: ${{values.workflow_id}}
   title: ${{values.title}}
   description: ${{values.description}}
   tags:


### PR DESCRIPTION
The software template to convert workflow to software template is relying on an updated version of the orchestrator custom action to accept the workflow_id as a parameter.